### PR TITLE
Attendre que _compute_autofocus soit chargé avant de l'utiliser

### DIFF
--- a/autofocus.rpy
+++ b/autofocus.rpy
@@ -162,12 +162,13 @@ python early in autofocus:
 
             return renpy.Render(0, 0)
 
-    config.per_frame_screens.append("_compute_autofocus")
-    config.always_shown_screens.append("_compute_autofocus")
-
 screen _compute_autofocus():
     for t in autofocus._autofocus_map:
         add autofocus._ComputeFocus(t)
+
+init python:
+    config.per_frame_screens.append("_compute_autofocus")
+    config.always_shown_screens.append("_compute_autofocus")
 
 default autofocus._autofocus_map = { }
 default autofocus._force_focus = set()


### PR DESCRIPTION
Voir https://discord.com/channels/848820726252306452/848829675206869002/1301954646579085394

Cette PR délaie l'ajout de `_compute_autofocus` à `config.per_frame_screens` et `config.always_shown_screens`.

Dans certains cas, Ren'Py peut faire un rendu de l'écran de jeu avant de charger les écrans mais après avoir interprété les blocs `early`. Dans de tels cas, il plantera si un écran ajouté à `config.per_frame_screens` ou `config.always_shown_screens` n'est pas encore défini.